### PR TITLE
Add bigstring as dependency

### DIFF
--- a/encore.opam
+++ b/encore.opam
@@ -26,5 +26,6 @@ depends: [
   "angstrom" {>= "0.10.0"}
   "fmt"
   "ke" {>= "0.3"}
+  "bigstringaf" {>= "0.5.0"}
   "alcotest" {with-test}
 ]

--- a/lib/dune
+++ b/lib/dune
@@ -2,4 +2,4 @@
  (name Encore)
  (public_name encore)
  (flags (:standard -w -32))
- (libraries butils ke angstrom fmt))
+ (libraries butils ke angstrom fmt bigstringaf))


### PR DESCRIPTION
It seems to me that `bigstringaf` is missing as a dependency in `lib/dune` and `encore.opam`. I get a compile error locally without these, though I see Travis is passing on `master` for some reason 🤔 