### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/encore.opam
+++ b/encore.opam
@@ -22,7 +22,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune"
   "angstrom" {>= "0.10.0"}
   "fmt"
   "ke" {>= "0.3"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.