### PR TITLE
Fix tests for angstrom 0.14.0

### DIFF
--- a/encore.opam
+++ b/encore.opam
@@ -23,7 +23,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune"
-  "angstrom" {>= "0.10.0"}
+  "angstrom" {>= "0.14.0"}
   "fmt"
   "ke" {>= "0.3"}
   "bigstringaf" {>= "0.5.0"}

--- a/test/test.ml
+++ b/test/test.ml
@@ -99,7 +99,7 @@ let parser =
    fun name (module Combinator) value sentinel s ->
     let of_string s =
       let module Dec = Combinator.Make (Proxy_decoder.Impl) in
-      match Angstrom.parse_string Dec.p s with
+      match Angstrom.parse_string ~consume:Prefix Dec.p s with
       | Ok v -> v
       | Error err -> invalid_arg err
     in
@@ -114,7 +114,7 @@ let parser =
    fun name (module Combinator) s ->
     let of_string s =
       let module Dec = Combinator.Make (Proxy_decoder.Impl) in
-      match Angstrom.parse_string Dec.p s with
+      match Angstrom.parse_string ~consume:Prefix Dec.p s with
       | Ok v -> v
       | Error err -> invalid_arg err
     in
@@ -404,7 +404,7 @@ let make : type sentinel.
   in
   let of_string s =
     let module Dec = Combinator.Make (Proxy_decoder.Impl) in
-    match Angstrom.parse_string Dec.p s with
+    match Angstrom.parse_string ~consume:Prefix Dec.p s with
     | Ok v -> v
     | Error err -> invalid_arg err
   in


### PR DESCRIPTION
`parse_string` now takes a required `~consume` argument. `~consume:Prefix`
achieves the previous behavior of `parse_string` and is necessary since
`Proxy_decoder` won't always consume all the input.