### PR TITLE
Better encoder

### DIFF
--- a/lib/encore.ml
+++ b/lib/encore.ml
@@ -161,11 +161,11 @@ module Syntax = struct
 
   let none = Pure (( = ), None)
 
+  let commit = Commit
+
   let rep1 p = fix @@ fun m -> Bij.cons <$> (p <*> (m <|> nil))
 
   let rep0 p = rep1 p <|> nil
-
-  let commit = Commit
 
   let sep_by1 ~sep p = Bij.cons <$> (p <*> rep0 (sep *> p))
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -330,6 +330,14 @@ let combinator =
           <|> (Bij.string "bar" <$> const "bar" <*> commit))
         Alcotest.(pair unit unit)
         ((), ()) "bar";
+      make_test "bar | fooz"
+        Syntax.(
+          Bij.string "bar"
+          <$> const "bar"
+          <*> commit
+          <|> (Bij.string "fooz" <$> const "fooz" <*> fail "fail"))
+        Alcotest.(pair unit unit)
+        ((), ()) "bar";
     ] in
   List.concat
     [


### PR DESCRIPTION
Related to mirage/irmin#1001 and mirage/ocaml-git#389 (only about the encoder).

For large Git objects, it can be difficult to parse/encode it where the alteration can still exist until we reach the `null` element. About the Git tree object, the alteration is resolved only when we reach the end of the list of entries. By this way, we denote a succession of alteration (`choice` operator) and each want to save the current position to possibly fallback to it if the first branch (eg. `p`) fails.

This PR reverse the order of application between `p` and `q`. Indeed, `q` should be a _pure_ element - it does not write anything into the output. Finally, this PR take the opportunity to _run_ `q` (which is probably _pure_) before `p` and _unfold_ the alteration.

This PR wants to solve the issue to encode/decode a large Git tree object without a keep of a large internal buffer. In fact, the old proposed solution is a bit quick & dirty where we only enlarged the internal buffer. With this PR, we are able to parse large objects with small internal buffers.

A test about large Git tree object is available here: mirage/ocaml-git#394