### PR TITLE
correctly handle char '\xff'

### DIFF
--- a/lib/encore.mli
+++ b/lib/encore.mli
@@ -178,7 +178,7 @@ module Syntax : sig
   val product : 'a t -> 'b t -> ('a * 'b) t
 
   val commit : unit t
-  (** [commit] prevents backtracking beyong the current position of the input,
+  (** [commit] prevents backtracking beyond the current position of the input,
       allowing the manager of the input buffer to reuse the preceding bytes for
       other purposes when the combinator is used as a parser.
 

--- a/lib/lavoisier.ml
+++ b/lib/lavoisier.ml
@@ -41,7 +41,7 @@ let flush k0 encoder =
 (* XXX(dinosaure): pre-allocate small strings. *)
 let ( <.> ) f g x = f (g x)
 
-let _chr = Array.init 255 (String.make 1 <.> Char.unsafe_chr)
+let _chr = Array.init 256 (String.make 1 <.> Char.unsafe_chr)
 
 let write_char chr k encoder =
   Deke.push encoder.dequeue _chr.(Char.code chr) ;


### PR DESCRIPTION
Fix this case:

```
let int_bij = Encore.Bij.v ~fwd:Char.code ~bwd:Char.chr
let int_enc = Encore.Syntax.(map int_bij any)
```

which previously generated an out-of-bounds exception when called upon to write `\xff`.